### PR TITLE
Cleanup of query responses

### DIFF
--- a/graphics/utils/database.py
+++ b/graphics/utils/database.py
@@ -31,7 +31,6 @@ class AlchemyEncoder(json.JSONEncoder):
 
 class Graphics(db.Model):
   __tablename__='graphics'
-  __bind_key__ = 'graphics'
   id = Column(Integer,primary_key=True)
   bibcode = Column(String,nullable=False,index=True)
   doi = Column(String)

--- a/graphics/views.py
+++ b/graphics/views.py
@@ -24,10 +24,9 @@ class Graphics(Resource):
            return {'msg': 'Unable to get results! (%s)' % err}, 500
        if results and results['query'] == 'OK':
            return results
-       elif results.get('error','NA') == 'no data':
-           return {'msg': 'No image data available! (%s)' % bibcode}, 204
        else:
-           return {'msg': 'Unable to get results! (%s)' % results.get('error','NA')}, 500
+           return {'msg': 'Unable to get results! (%s)' % results.get('error','NA')}, 404
+
 class DisplayGraphics(Resource):
     """Return image data for a given figure"""
     scopes = []


### PR DESCRIPTION
Graphics service will now respond with '200' and graphics data for records with a valid entry in the database, with 500 (and an error message in the response data) if the database connection blew up and 404 in all other cases (and an error message in the response data)