### PR TITLE
Necessary updates for IOP pipeline

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ werkzeug
 psycopg2
 SQLAlchemy
 simplejson>=3.3.0
-requests
+requests>=2.7.0
 mock
 coveralls
 httpretty


### PR DESCRIPTION
Changes to deal with:

- changed IOP fulltext format (captions now have IDs and no longer thumbnail links in XML)
- check thumbnail URL if it returns 200, because AIE may not have the record yet