### PR TITLE
Scix id support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Start with
   
 and do a request from the command line like so
 
-	curl http://localhost:4000/1995ApJ...447L..37W
+	curl http://localhost:4000/<identifier>
 
-and you should get back graphics data
+and you should get back graphics data. The identifier supplied should either be a bibcode or a SciX ID.

--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ and do a request from the command line like so
 
 	curl http://localhost:4000/<identifier>
 
-and you should get back graphics data. The identifier supplied should either be a bibcode or a SciX ID.
+and you should get back graphics data. The identifier supplied should either be a bibcode or a SciX ID (example: `scix:9XSY-FJXA-8SQY`).

--- a/alembic/versions/acbec150bf50_add_scix_id_column_to_graphics_db.py
+++ b/alembic/versions/acbec150bf50_add_scix_id_column_to_graphics_db.py
@@ -1,0 +1,23 @@
+"""Add scix_id column to graphics db
+
+Revision ID: acbec150bf50
+Revises: de7cb4b6482f
+Create Date: 2025-08-26 14:07:37.099701
+
+"""
+from alembic import op
+from sqlalchemy import Column, String, Integer, TIMESTAMP, DateTime, Text, Index, Boolean
+
+# revision identifiers, used by Alembic.
+revision = 'acbec150bf50'
+down_revision = 'de7cb4b6482f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('graphics', Column('scix_id', String(19), nullable = True, default=None, unique=True))
+
+
+def downgrade():
+    op.drop_column('graphics', 'scix_id')

--- a/config.py
+++ b/config.py
@@ -1,12 +1,12 @@
 LOG_STDOUT = True
 # External graphics sources
-GRAPHICS_EXTSOURCES = ['IOP', 'Elsevier', 'EDP', 'OUP', 'APS', 'AnnRev']
+GRAPHICS_EXTSOURCES = ['IOP', 'AAS', 'Elsevier', 'EDP', 'OUP', 'APS', 'AnnRev']
 # Some info for the external site
 GRAPHICS_HEADER = {
                   'EDP':'Every image links to the article on <a href="http://www.aanda.org/" target="_new">Astronomy &amp; Astrophysics</a>',
                   'OUP':'Every image links to the article on <a href="https://academic.oup.com/mnras/" target="_new">Monthly Notices of the RAS</a>',
-                  'IOP':'Every image links to the <a href="http://www.astroexplorer.org/" target="_new">AAS "Astronomy Image Explorer"</a> for more detail.',
-                  'IOPscience':'Every image links to the article on <a href="http://iopscience.iop.org/" target="_new">IOPscience</a>',
+                  'AAS':'Every image links to the <a href="http://www.astroexplorer.org/" target="_new">AAS "Astronomy Image Explorer"</a> for more detail.',
+                  'IOP':'Every image links to the article on <a href="http://iopscience.iop.org/" target="_new">IOPscience</a>',
                   'Elsevier':'Every image links to the article on <a href="http://www.sciencedirect.com" target="_new">ScienceDirect</a>',
                   'APS': 'Every image links to the article on <a href="https://journals.aps.org/" target="_new">Physical Review Journals</a>',
                   'AnnRev': 'Every image links to the article on <a href="https://www.annualreviews.org/action/showPublications" target="_new">Annual Reviews</a>'
@@ -14,7 +14,8 @@ GRAPHICS_HEADER = {
 #
 GRAPHICS_INCLUDE_ARXIV = True
 # Proper handling of database connections
-SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://user:pwd@localhost:5432/graphics'
+SQLALCHEMY_BINDS = {u'graphics': u'postgresql+psycopg2://graphics:graphics@localhost:5432/graphics'}
+SQLALCHEMY_DATABASE_URI = 'postgresql+psycopg2://graphics:graphics@localhost:5432/graphics'
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 # Define the autodiscovery endpoint

--- a/graphics_service/app.py
+++ b/graphics_service/app.py
@@ -21,7 +21,7 @@ def create_app(**config):
     app.url_map.strict_slashes = False
 
     api = Api(app)
-    api.add_resource(Graphics, '/<string:bibcode>')
+    api.add_resource(Graphics, '/<string:identifier>')
 
     Discoverer(app)
 

--- a/graphics_service/graphics.py
+++ b/graphics_service/graphics.py
@@ -29,7 +29,7 @@ def get_graphics(identifier):
         output['scix_id'] = results['scix_id']
         # We still include the value in the "bibcode" column in the output
         # For backwards compatibility
-        output['bibcode'] = results['bibcode']
+        output['bibcode'] = results.get('bibcode')
         output['number'] = len(results['thumbnails'])
         output['pick'] = graph_link % random.choice(results['thumbnails'])
         if not output['pick'].find('http') >-1:

--- a/graphics_service/graphics.py
+++ b/graphics_service/graphics.py
@@ -27,6 +27,9 @@ def get_graphics(identifier):
         output = {}
         source = results.get('source', 'NA')
         output['scix_id'] = results['scix_id']
+        # We still include the value in the "bibcode" column in the output
+        # For backwards compatibility
+        output['bibcode'] = results['bibcode']
         output['number'] = len(results['thumbnails'])
         output['pick'] = graph_link % random.choice(results['thumbnails'])
         if not output['pick'].find('http') >-1:

--- a/graphics_service/graphics.py
+++ b/graphics_service/graphics.py
@@ -13,9 +13,9 @@ from .models import get_graphics_record
 
 graph_link = '<a href="graphics" border=0><img src="%s"></a>'
 
-def get_graphics(bibcode):
-    # Query graphics database with bibcode supplied
-    results = get_graphics_record(bibcode)
+def get_graphics(identifier):
+    # Query graphics database with identifier supplied
+    results = get_graphics_record(identifier)
     if results and 'thumbnails' in results:
         try:
             thumbnail_count = len(results['thumbnails'])
@@ -23,14 +23,14 @@ def get_graphics(bibcode):
             thumbnail_count = 0
         if thumbnail_count == 0:
             # No thumbnails = nothing to display
-            return {'Error': 'Unable to get results!', 'Error Info': 'No thumbnail data for %s' % bibcode}
+            return {'Error': 'Unable to get results!', 'Error Info': 'No thumbnail data for %s' % identifier}
         output = {}
         source = results.get('source', 'NA')
-        output['bibcode'] = results['bibcode']
+        output['scix_id'] = results['scix_id']
         output['number'] = len(results['thumbnails'])
         output['pick'] = graph_link % random.choice(results['thumbnails'])
         if not output['pick'].find('http') >-1:
-            return {'Error': 'Unable to get results!', 'Error Info': 'Failed to get thumbnail for display image for %s' % output['bibcode']}
+            return {'Error': 'Unable to get results!', 'Error Info': 'Failed to get thumbnail for display image for %s' % output['scix_id']}
         # Create this convoluted construct for backwards compatibility
         output['figures'] = []
         n=1
@@ -44,9 +44,6 @@ def get_graphics(bibcode):
             output['figures'].append(fig_data)
             n+=1
         if source in current_app.config.get('GRAPHICS_EXTSOURCES'):
-            # Non-AAS journals link to IOPscience, rather than AIE
-            if source == "IOP" and bibcode[4:9] not in ['ApJ..','ApJS.','AJ...']:
-                source = "IOPscience"
             header = current_app.config.get('GRAPHICS_HEADER').get(source,'')
             output['header'] =  header
         elif source.upper() == 'ARXIV' \
@@ -55,7 +52,8 @@ def get_graphics(bibcode):
         elif source.upper() == 'TEST':
             output['pick'] = random.choice(results['thumbnails'])
         else:
-            output = {'Error': 'Unable to get results!', 'Error Info': 'Unknown data source %s' % source} 
+            output = {'Error': 'Unable to get results!', 'Error Info': 'Unknown data source %s' % source}
+
         return output
 
     return results

--- a/graphics_service/models.py
+++ b/graphics_service/models.py
@@ -5,7 +5,7 @@ Created on Nov 2, 2014
 '''
 
 import simplejson as json
-from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from sqlalchemy import Column, Integer, String, DateTime, Boolean, or_
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm.exc import NoResultFound
@@ -52,8 +52,9 @@ class GraphicsModel(Base):
 
 def execute_SQL_query(ident):
     with current_app.session_scope() as session:
+        # Filter against both scix_id and bibcode columns for backwards compatibility
         resp = session.query(GraphicsModel).filter(
-             GraphicsModel.scix_id == ident).one()
+             or_(GraphicsModel.scix_id == ident, GraphicsModel.bibcode == ident)).one()
         results = json.loads(json.dumps(resp, cls=AlchemyEncoder))
         return results
 

--- a/graphics_service/models.py
+++ b/graphics_service/models.py
@@ -41,6 +41,7 @@ class GraphicsModel(Base):
     __tablename__ = 'graphics'
     id = Column(Integer, primary_key=True)
     bibcode = Column(String, nullable=False, index=True)
+    scix_id = Column(String(19), nullable=True, unique=True, index=True)
     doi = Column(String)
     source = Column(String)
     eprint = Column(Boolean)
@@ -49,18 +50,18 @@ class GraphicsModel(Base):
     baseurl = Column(String)
     modtime = Column(DateTime)
 
-def execute_SQL_query(bibc):
+def execute_SQL_query(ident):
     with current_app.session_scope() as session:
         resp = session.query(GraphicsModel).filter(
-             GraphicsModel.bibcode == bibc).one()
+             GraphicsModel.scix_id == ident).one()
         results = json.loads(json.dumps(resp, cls=AlchemyEncoder))
         return results
 
-def get_graphics_record(bibcode):
+def get_graphics_record(identifier):
     try:
-        res = execute_SQL_query(bibcode)
+        res = execute_SQL_query(identifier)
     except NoResultFound:
-        res = {'Error': 'Unable to get results!', 'Error Info': 'No database entry found for %s' % bibcode}
+        res = {'Error': 'Unable to get results!', 'Error Info': 'No database entry found for %s' % identifier}
     except Exception as err:
-        res = {'Error': 'Unable to get results!', 'Error Info': 'Graphics query failed for %s: %s'%(bibcode, err)}
+        res = {'Error': 'Unable to get results!', 'Error Info': 'Graphics query failed for %s: %s'%(identifier, err)}
     return res

--- a/graphics_service/models.py
+++ b/graphics_service/models.py
@@ -8,7 +8,7 @@ import simplejson as json
 from sqlalchemy import Column, Integer, String, DateTime, Boolean, or_
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.dialects import postgresql
 from flask_sqlalchemy import SQLAlchemy
 from flask import current_app
@@ -63,6 +63,8 @@ def get_graphics_record(identifier):
         res = execute_SQL_query(identifier)
     except NoResultFound:
         res = {'Error': 'Unable to get results!', 'Error Info': 'No database entry found for %s' % identifier}
+    except MultipleResultsFound:
+        res = {'Error': 'Unable to get results!', 'Error Info': 'Multiple results were found for %s' % identifier}
     except Exception as err:
         res = {'Error': 'Unable to get results!', 'Error Info': 'Graphics query failed for %s: %s'%(identifier, err)}
     return res

--- a/graphics_service/tests/test_endpoint.py
+++ b/graphics_service/tests/test_endpoint.py
@@ -150,11 +150,11 @@ class TestExpectedResults(TestCase):
         expected = {u'Error Info': u'No thumbnail data for foo', u'Error': u'Unable to get results!'}
         self.assertTrue(r.json == expected)
 
-    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data, source='IOPscience'))
+    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data, source='AAS'))
     def test_query_IOPScience(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        header = self.app.config.get('GRAPHICS_HEADER').get('IOPscience')
+        header = self.app.config.get('GRAPHICS_HEADER').get('AAS')
         url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)

--- a/graphics_service/tests/test_endpoint.py
+++ b/graphics_service/tests/test_endpoint.py
@@ -22,6 +22,7 @@ def get_testdata(figures = [], thumbnails=[], source='TEST'):
     thumbs = [(f['images'][0].get('thumbnail',''),f['images'][0].get('thumnail','')) for f in figures]
     g = GraphicsModel(
         bibcode='9999BBBBBVVVVQPPPPI',
+        scix_id='scix:5EZ7-KFJK-SXW9',
         doi='DOI',
         source=source,
         eprint=False,
@@ -32,16 +33,27 @@ def get_testdata(figures = [], thumbnails=[], source='TEST'):
     results = json.loads(json.dumps(g, cls=AlchemyEncoder))
     return results
 
-class TestExpectedResults(TestCase):
-    figure_data = [{'images': [{'thumbnail': 'http://fg1_thumb_url', 'highres':''}], 
+figure_data = [{'images': [{'thumbnail': 'http://fg1_thumb_url', 'highres':''}], 
                 'figure_caption': '', 
                 'figure_label': 'Figure 1', 
                 'figure_type': u''}]
 
-    figure_data_no_thumb = [{"images": [{"image_id": "fg1", "format": "gif"}],
+figure_data_no_thumb = [{"images": [{"image_id": "fg1", "format": "gif"}],
                 "figure_caption": "Figure 1",
                 "figure_label": "Figure 1",
                 "figure_id": "fg1"}]
+
+class TestExpectedResults(TestCase):
+
+#    figure_data = [{'images': [{'thumbnail': 'http://fg1_thumb_url', 'highres':''}], 
+#                'figure_caption': '', 
+#                'figure_label': 'Figure 1', 
+#                'figure_type': u''}]
+#
+#    figure_data_no_thumb = [{"images": [{"image_id": "fg1", "format": "gif"}],
+#                "figure_caption": "Figure 1",
+#                "figure_label": "Figure 1",
+#                "figure_id": "fg1"}]
 
     def create_app(self):
         '''Create the wsgi application'''
@@ -58,8 +70,9 @@ class TestExpectedResults(TestCase):
         uc = Column(String)
         dc = Column(DateTime)
         cols_expect = list(map(
-            type, [ic.type, sc.type, sc.type, sc.type, bc.type,
+            type, [ic.type, sc.type, sc.type, sc.type, sc.type, bc.type,
                    jc.type, tc.type, uc.type, dc.type]))
+
         self.assertEqual([type(c.type)
                           for c in GraphicsModel.__table__.columns],
                          cols_expect)
@@ -68,30 +81,30 @@ class TestExpectedResults(TestCase):
     def test_query(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
-        self.assertTrue(r.json.get('figures') == self.figure_data)
-        self.assertTrue(r.json.get('bibcode') == '9999BBBBBVVVVQPPPPI')
+        self.assertTrue(r.json.get('figures') == figure_data)
+        self.assertTrue(r.json.get('scix_id') == 'scix:5EZ7-KFJK-SXW9')
 
     @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data_no_thumb, source='IOP'))
     def test_query_no_thumbnail(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='9999ApJ..VVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
-        expected = {u'Error Info': u'Failed to get thumbnail for display image for 9999BBBBBVVVVQPPPPI', u'Error': u'Unable to get results!'}
+        expected = {u'Error Info': u'Failed to get thumbnail for display image for scix:5EZ7-KFJK-SXW9', u'Error': u'Unable to get results!'}
         self.assertTrue(r.json == expected)
 
     @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data_no_thumb, source='ARXIV'))
     def test_query_no_thumbnail_2(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='9999ApJ..VVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
-        expected = {u'Error Info': u'Failed to get thumbnail for display image for 9999BBBBBVVVVQPPPPI', u'Error': u'Unable to get results!'}
+        expected = {u'Error Info': u'Failed to get thumbnail for display image for scix:5EZ7-KFJK-SXW9', u'Error': u'Unable to get results!'}
         self.assertTrue(r.json == expected)
 
     @mock.patch('graphics_service.models.execute_SQL_query')
@@ -99,7 +112,7 @@ class TestExpectedResults(TestCase):
         ''''An exception is returned representing the absence of
             a database connection'''
         mock_execute_SQL_query.side_effect = Exception('something went wrong')
-        url = url_for('graphics', bibcode='foo')
+        url = url_for('graphics', identifier='foo')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         expected = {u'Error Info': u'Graphics query failed for foo: something went wrong', u'Error': u'Unable to get results!'}
@@ -110,7 +123,7 @@ class TestExpectedResults(TestCase):
         ''''An exception is returned representing the absence of
             a record in the database'''
         mock_execute_SQL_query.side_effect = NoResultFound
-        url = url_for('graphics', bibcode='foo')
+        url = url_for('graphics', identifier='foo')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         expected = {u'Error Info': u'No database entry found for foo', u'Error': u'Unable to get results!'}
@@ -121,7 +134,7 @@ class TestExpectedResults(TestCase):
     def test_query_error(self, mock_execute_SQL_query):
         ''''An exception is returned representing the absence of
             a database connection'''
-        url = url_for('graphics', bibcode='foo')
+        url = url_for('graphics', identifier='foo')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         expected = {u'Error Info': u'info', u'Error': u'error'}
@@ -131,18 +144,18 @@ class TestExpectedResults(TestCase):
     def test_query_no_data(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='foo')
+        url = url_for('graphics', identifier='foo')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         expected = {u'Error Info': u'No thumbnail data for foo', u'Error': u'Unable to get results!'}
         self.assertTrue(r.json == expected)
 
-    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data, source='IOP'))
+    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data, source='IOPscience'))
     def test_query_IOPScience(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
         header = self.app.config.get('GRAPHICS_HEADER').get('IOPscience')
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         self.assertEqual(r.json['header'], header)
@@ -152,7 +165,7 @@ class TestExpectedResults(TestCase):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
         header = self.app.config.get('GRAPHICS_HEADER').get('IOP')
-        url = url_for('graphics', bibcode='9999ApJ..VVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         self.assertEqual(r.json['header'], header)
@@ -162,7 +175,7 @@ class TestExpectedResults(TestCase):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
         header = self.app.config.get('GRAPHICS_HEADER').get('EDP')
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         self.assertEqual(r.json['header'], header)
@@ -172,7 +185,7 @@ class TestExpectedResults(TestCase):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
         header = self.app.config.get('GRAPHICS_HEADER').get('Elsevier')
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         self.assertEqual(r.json['header'], header)
@@ -181,7 +194,7 @@ class TestExpectedResults(TestCase):
     def test_query_arXiv(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         header = 'Images extracted from the arXiv e-print'
         self.assertTrue(r.status_code == 200)
@@ -191,7 +204,7 @@ class TestExpectedResults(TestCase):
     def test_query_unknown_source(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
-        url = url_for('graphics', bibcode='9999BBBBBVVVVQPPPPI')
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)
         self.assertTrue(r.status_code == 200)
         expected = {u'Error Info': u'Unknown data source FOO', u'Error': u'Unable to get results!'}

--- a/graphics_service/tests/test_endpoint.py
+++ b/graphics_service/tests/test_endpoint.py
@@ -78,7 +78,7 @@ class TestExpectedResults(TestCase):
                          cols_expect)
 
     @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data))
-    def test_query(self, mock_execute_SQL_query):
+    def test_query_with_scixid(self, mock_execute_SQL_query):
         '''Query endpoint with bibcode from stub data should
            return expected results'''
         url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
@@ -86,6 +86,18 @@ class TestExpectedResults(TestCase):
         self.assertTrue(r.status_code == 200)
         self.assertTrue(r.json.get('figures') == figure_data)
         self.assertTrue(r.json.get('scix_id') == 'scix:5EZ7-KFJK-SXW9')
+
+    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data))
+    def test_query_with_bibcode(self, mock_execute_SQL_query):
+        '''Query endpoint with bibcode from stub data should
+           return expected results'''
+        url = url_for('graphics', identifier='9999BBBBBVVVVQPPPPI')
+        r = self.client.get(url)
+        self.assertTrue(r.status_code == 200)
+        self.assertTrue(r.json.get('figures') == figure_data)
+        self.assertTrue(r.json.get('scix_id') == 'scix:5EZ7-KFJK-SXW9')
+        # The bibcode is still returned for backwards compatibility and testing
+        self.assertTrue(r.json.get('bibcode') == '9999BBBBBVVVVQPPPPI')
 
     @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data_no_thumb, source='IOP'))
     def test_query_no_thumbnail(self, mock_execute_SQL_query):

--- a/graphics_service/tests/test_endpoint.py
+++ b/graphics_service/tests/test_endpoint.py
@@ -18,10 +18,10 @@ import simplejson as json
 import mock
 from datetime import datetime
 
-def get_testdata(figures = [], thumbnails=[], source='TEST'):
+def get_testdata(figures = [], thumbnails=[], source='TEST', bibcode='9999BBBBBVVVVQPPPPI'):
     thumbs = [(f['images'][0].get('thumbnail',''),f['images'][0].get('thumnail','')) for f in figures]
     g = GraphicsModel(
-        bibcode='9999BBBBBVVVVQPPPPI',
+        bibcode=bibcode,
         scix_id='scix:5EZ7-KFJK-SXW9',
         doi='DOI',
         source=source,
@@ -79,7 +79,17 @@ class TestExpectedResults(TestCase):
 
     @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data))
     def test_query_with_scixid(self, mock_execute_SQL_query):
-        '''Query endpoint with bibcode from stub data should
+        '''Query endpoint with SciX ID from stub data should
+           return expected results'''
+        url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
+        r = self.client.get(url)
+        self.assertTrue(r.status_code == 200)
+        self.assertTrue(r.json.get('figures') == figure_data)
+        self.assertTrue(r.json.get('scix_id') == 'scix:5EZ7-KFJK-SXW9')
+
+    @mock.patch('graphics_service.models.execute_SQL_query', return_value=get_testdata(figures=figure_data, bibcode=None))
+    def test_query_with_scixid_without_bibcode(self, mock_execute_SQL_query):
+        '''Query endpoint with SciX ID from stub data should
            return expected results'''
         url = url_for('graphics', identifier='scix:5EZ7-KFJK-SXW9')
         r = self.client.get(url)

--- a/graphics_service/tests/test_internals.py
+++ b/graphics_service/tests/test_internals.py
@@ -15,6 +15,7 @@ from datetime import datetime
 def get_testdata(figures = []):
     g = GraphicsModel(
         bibcode='9999BBBBBVVVVQPPPPI',
+        scix_id='scix:5EZ7-KFJK-SXW9',
         doi='DOI',
         source='TEST',
         eprint=False,
@@ -45,6 +46,7 @@ class TestUtils(TestCase):
 
         g = GraphicsModel(
                 bibcode='bibcode',
+                scix_id='scix_id',
                 doi='DOI',
                 source='TEST',
                 eprint=False,
@@ -54,7 +56,7 @@ class TestUtils(TestCase):
         results = json.loads(json.dumps(g, cls=AlchemyEncoder))
         expected = {'modtime': None, 'bibcode': 'bibcode', 'thumbnails': None,
                     'baseurl': None, 'source': 'TEST', 'doi': 'DOI', 'figures': [],
-                    'eprint': False, 'id': None}
+                    'eprint': False, 'id': None, 'scix_id': 'scix_id'}
         self.assertTrue(results==expected)
 
 class TestLocalConfig(TestCase):
@@ -78,6 +80,7 @@ class TestDatabaseQuery(TestCase):
         '''Create the wsgi application'''
         g = GraphicsModel(
                 bibcode='bibcode',
+                scix_id='scix_id',
                 doi='DOI',
                 source='TEST',
                 eprint=False,

--- a/graphics_service/views.py
+++ b/graphics_service/views.py
@@ -12,9 +12,9 @@ class Graphics(Resource):
     rate_limit = [1000, 60 * 60 * 24]
     decorators = [advertise('scopes', 'rate_limit')]
 
-    def get(self, bibcode):
+    def get(self, identifier):
         stime = time.time()
-        results = get_graphics(bibcode)
+        results = get_graphics(identifier)
         duration = time.time() - stime
-        current_app.logger.info('Graphics for %s in %s user seconds'%(bibcode, duration))
+        current_app.logger.info('Graphics for %s in %s user seconds'%(identifier, duration))
         return results, 200


### PR DESCRIPTION
This update update of the `graphics_service` accomplishes the following:

- Alembic update of the database schema that adds one column to hold SciX IDs
- Update the query logic so that backward compatibility is guaranteed (bibcodes and SciX IDs are both supported)
- Appropriate renaming of variables to de-prioritize the bibcode

The query
```
        resp = session.query(GraphicsModel).filter(
             or_(GraphicsModel.scix_id == ident, GraphicsModel.bibcode == ident)).one()
        results = json.loads(json.dumps(resp, cls=AlchemyEncoder))
```
will fail if the `scix_id` column does not exsist. Since this column will be added with this new release, it seems unnecessary to require the code to be able to run against a database with the old schema.

After the new release has been deployed, the database with be provisioned with appropriate SciX ID values.